### PR TITLE
Fixing some configs about ruff 0.9.6 version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY pyproject.toml .
 RUN pip install poetry
 
 FROM base AS dependencies
-RUN poetry install --no-dev
+RUN poetry install --without dev
 
 FROM base AS development
 RUN poetry install

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   fast-api-boilerplate-project:
     tty: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,16 +4,17 @@ version = "0.1.0"
 description = "it's a simple and useful boilerplate for python projects using fast api framework"
 authors = ["Authors Name <authorsmail@>"]
 license = "MIT"
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.11"
-fastapi = "0.115.6"
+fastapi = "0.115.8"
 uvicorn = "0.34.0"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "8.3.4"
 pytest-cov = "^6.0.0"
-ruff = "^0.8.1"
+ruff = "^0.9.6"
 httpx = "0.28.1"
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
ref: https://github.com/marcieltorres/python-boilerplate-project/pull/66
## What changes do you are proposing? 

- Upgrading ruff to 0.9.6 version
- Upgrading fast api to 0.115.8 version
- Fixing pyprojetct config adding package mode 
- Using `poetry.group.dev.dependencies` instead of deprecated `poetry.dev-dependencies`
- Removing `version` from docker compose file because is obsolete;