### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -3,6 +3,8 @@ on: [pull_request]
 jobs:
   run_tests_and_lint:
     name: "Run Tests and Lint"
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - run: echo "Running build and test for ${{ github.ref }} branch"


### PR DESCRIPTION
Potential fix for [https://github.com/marcieltorres/fast-api-boilerplate-project/security/code-scanning/1](https://github.com/marcieltorres/fast-api-boilerplate-project/security/code-scanning/1)

To fix the problem, explicitly add a `permissions:` block to the job definition in `.github/workflows/pull_request.yml` (inside the `run_tests_and_lint` job). Since the only actions used are `actions/checkout` (which can operate with `contents: read`), and no steps involve modifying issues, PRs, or repository contents, you may safely restrict permissions to the minimum: `contents: read`. Add the following block under `run_tests_and_lint:`:

```yaml
permissions:
  contents: read
```

This change should be made directly after line 5, before `runs-on: ubuntu-latest`. No imports or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
